### PR TITLE
Correctly bump tag of main

### DIFF
--- a/.github/workflows/main-tag-bump.yml
+++ b/.github/workflows/main-tag-bump.yml
@@ -12,7 +12,19 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.4
+      with:
+        versionSpec: '5.3.x'
+    - name: Use GitVersion
+      id: gitversion # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v0.9.4
+    - run: |
+        echo "NuGetVersionV2: ${{ steps.gitversion.outputs.NuGetVersionV2 }}"
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.17.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # We want to push to nuget the same version we tag
+        CUSTOM_TAG: ${{ steps.gitversion.outputs.NuGetVersionV2 }}
+        RELEASE_BRANCHES: main


### PR DESCRIPTION
Make sure to tie tag version to NuGetVersionV2, to match NuGet pushed version.